### PR TITLE
[MM-36011] reference mattermost github repo throughout code, not the authors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters-settings:
   gofmt:
     simplify: true
   goimports:
-    local-prefixes: github.com/kosgrz/mattermost-plugin-bitbucket
+    local-prefixes: github.com/mattermost/mattermost-plugin-bitbucket
   golint:
     min-confidence: 0
   govet:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Configuration is started in Bitbucket and completed in Mattermost.
 3. Click the **Add consumer** button and set the following values:
    - **Name:** `Mattermost Bitbucket Plugin - <your company name>`.
    - **Callback URL:** `https://your-mattermost-url.com/plugins/bitbucket/oauth/complete`, replacing `https://your-mattermost-url.com` with your Mattermost URL.
-   - **URL:** `https://github.com/kosgrz/mattermost-plugin-bitbucket`.
+   - **URL:** `https://github.com/mattermost/mattermost-plugin-bitbucket`.
 4. Set:
    - **Account:** `Email` and `Read` permissions.
    - **Projects:** `Read` permission.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kosgrz/mattermost-plugin-bitbucket
+module github.com/mattermost/mattermost-plugin-bitbucket
 
 go 1.12
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/testutils"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/testutils"
 )
 
 func TestPlugin_ServeHTTP(t *testing.T) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/templaterenderer"
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhook"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/templaterenderer"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhook"
 
 	"net/http"
 	"net/url"

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wbrefvem/go-bitbucket"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/subscription"
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/subscription"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 const (

--- a/server/subscriptions_test.go
+++ b/server/subscriptions_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/subscription"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/subscription"
 )
 
 func CheckError(t *testing.T, wantErr bool, err error) {

--- a/server/templaterenderer/issue.go
+++ b/server/templaterenderer/issue.go
@@ -3,7 +3,7 @@ package templaterenderer
 import (
 	"errors"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 func (tr *templateRenderer) RenderIssueCreatedEventNotificationForSubscribedChannels(pl webhookpayload.Payload) (string, error) {

--- a/server/templaterenderer/pullrequest.go
+++ b/server/templaterenderer/pullrequest.go
@@ -1,7 +1,7 @@
 package templaterenderer
 
 import (
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 func (tr *templateRenderer) RenderPullRequestCreatedEventNotificationForSubscribedChannels(pl webhookpayload.PullRequestCreatedPayload) (string, error) {

--- a/server/templaterenderer/push.go
+++ b/server/templaterenderer/push.go
@@ -1,7 +1,7 @@
 package templaterenderer
 
 import (
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 func (tr *templateRenderer) RenderRepoPushEventNotificationForSubscribedChannels(pl webhookpayload.RepoPushPayload) (string, error) {

--- a/server/templaterenderer/template.go
+++ b/server/templaterenderer/template.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 type BitBucketAccountIDToUsernameMappingCallbackType func(string) string

--- a/server/templaterenderer/template_fixture_test.go
+++ b/server/templaterenderer/template_fixture_test.go
@@ -1,7 +1,7 @@
 package templaterenderer
 
 import (
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 var mmUserBitbucketAccountID = "123"

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/mattermost/mattermost-server/v5/model"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/subscription"
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhook"
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/subscription"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhook"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 const (

--- a/server/webhook/issue.go
+++ b/server/webhook/issue.go
@@ -1,7 +1,7 @@
 package webhook
 
 import (
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 
 	"github.com/pkg/errors"
 )

--- a/server/webhook/pullrequest.go
+++ b/server/webhook/pullrequest.go
@@ -1,7 +1,7 @@
 package webhook
 
 import (
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 
 	"github.com/pkg/errors"
 )

--- a/server/webhook/push.go
+++ b/server/webhook/push.go
@@ -1,7 +1,7 @@
 package webhook
 
 import (
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 func (w *webhook) HandleRepoPushEvent(pl webhookpayload.RepoPushPayload) ([]*HandleWebhook, error) {

--- a/server/webhook/webhook.go
+++ b/server/webhook/webhook.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/subscription"
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/templaterenderer"
-	"github.com/kosgrz/mattermost-plugin-bitbucket/server/webhookpayload"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/subscription"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/templaterenderer"
+	"github.com/mattermost/mattermost-plugin-bitbucket/server/webhookpayload"
 )
 
 const (


### PR DESCRIPTION
#### Summary
This PR substitutes all `github.com/kosgrz/mattermost-plugin-bitbucket` imports for `github.com/mattermost/mattermost-plugin-bitbucket`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36011

resolves https://github.com/mattermost/mattermost-plugin-bitbucket/issues/21