### PR TITLE
[GH-24] Use secret when processing webhook call

### DIFF
--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -30,7 +30,9 @@ You must create a webhook for each repository you want to receive notifications 
 2. Select **Add Webhook**.
 3. Set the following values:
    * **Title:** `Mattermost Bitbucket Webhook - <repository_name>`, replacing `repository_name` with the name of your repository.
-   * **URL:** `https://your-mattermost-url.com/plugins/bitbucket/webhook`, replacing `https://your-mattermost-url.com` with your Mattermost deployment's Site URL.
+   * **URL:** `https://your-mattermost-url.com/plugins/bitbucket/webhook/your-webhook-secret`
+      * replace `https://your-mattermost-url.com` with your Mattermost deployment's Site URL.
+      * replace `your-webhook-secret` with the secret generated in System Console > Plugins > Bitbucket > Webhook Secret
 4. Select **Choose from a full list of triggers**.
 5. Select:
    * **Repository:** `Push`.

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -30,9 +30,9 @@ You must create a webhook for each repository you want to receive notifications 
 2. Select **Add Webhook**.
 3. Set the following values:
    * **Title:** `Mattermost Bitbucket Webhook - <repository_name>`, replacing `repository_name` with the name of your repository.
-   * **URL:** `https://your-mattermost-url.com/plugins/bitbucket/webhook/your-webhook-secret`
+   * **URL:** `https://your-mattermost-url.com/plugins/bitbucket/webhook?secret=SOME_SECRET`
       * replace `https://your-mattermost-url.com` with your Mattermost deployment's Site URL.
-      * replace `your-webhook-secret` with the secret generated in System Console > Plugins > Bitbucket > Webhook Secret.
+      * replace `SOME_SECRET` with the secret generated in System Console > Plugins > Bitbucket > Webhook Secret.
 4. Select **Choose from a full list of triggers**.
 5. Select:
    * **Repository:** `Push`.

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -32,7 +32,7 @@ You must create a webhook for each repository you want to receive notifications 
    * **Title:** `Mattermost Bitbucket Webhook - <repository_name>`, replacing `repository_name` with the name of your repository.
    * **URL:** `https://your-mattermost-url.com/plugins/bitbucket/webhook/your-webhook-secret`
       * replace `https://your-mattermost-url.com` with your Mattermost deployment's Site URL.
-      * replace `your-webhook-secret` with the secret generated in System Console > Plugins > Bitbucket > Webhook Secret
+      * replace `your-webhook-secret` with the secret generated in System Console > Plugins > Bitbucket > Webhook Secret.
 4. Select **Choose from a full list of triggers**.
 5. Select:
    * **Repository:** `Push`.

--- a/server/api.go
+++ b/server/api.go
@@ -100,7 +100,7 @@ func (p *Plugin) initializeAPI() {
 	oauthRouter := p.router.PathPrefix("/oauth").Subrouter()
 	apiRouter := p.router.PathPrefix("/api/v1").Subrouter()
 
-	p.router.HandleFunc("/webhook", p.handleWebhook).Methods(http.MethodPost)
+	p.router.HandleFunc("/webhook/{webhooksecret}", p.handleWebhook).Methods(http.MethodPost)
 
 	oauthRouter.HandleFunc("/connect", p.extractUserMiddleWare(p.connectUserToBitbucket, ResponseTypePlain)).Methods(http.MethodGet)
 	oauthRouter.HandleFunc("/complete", p.extractUserMiddleWare(p.completeConnectUserToBitbucket, ResponseTypePlain)).Methods(http.MethodGet)

--- a/server/api.go
+++ b/server/api.go
@@ -100,7 +100,7 @@ func (p *Plugin) initializeAPI() {
 	oauthRouter := p.router.PathPrefix("/oauth").Subrouter()
 	apiRouter := p.router.PathPrefix("/api/v1").Subrouter()
 
-	p.router.HandleFunc("/webhook/{webhooksecret}", p.handleWebhook).Methods(http.MethodPost)
+	p.router.HandleFunc("/webhook", p.handleWebhook).Methods(http.MethodPost)
 
 	oauthRouter.HandleFunc("/connect", p.extractUserMiddleWare(p.connectUserToBitbucket, ResponseTypePlain)).Methods(http.MethodGet)
 	oauthRouter.HandleFunc("/complete", p.extractUserMiddleWare(p.completeConnectUserToBitbucket, ResponseTypePlain)).Methods(http.MethodGet)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -47,6 +47,9 @@ func (c *Configuration) IsValid() error {
 		return errors.New("must have an encryption key")
 	}
 
+	if c.WebhookSecret == "" {
+		return errors.New("must have a webhook secret")
+	}
 	return nil
 }
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -22,12 +22,9 @@ const (
 func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	secret := r.URL.Query().Get("secret")
 	config := p.getConfiguration()
-	if err := config.IsValid(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+
 	if config.WebhookSecret == "" {
-		http.Error(w, "Webhook not found in config", http.StatusInternalServerError)
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(config.WebhookSecret), []byte(secret)) == 0 {

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/model"
 
 	"github.com/kosgrz/mattermost-plugin-bitbucket/server/subscription"
@@ -19,6 +20,12 @@ const (
 )
 
 func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+
+	if p.configuration.WebhookSecret != params["webhooksecret"] {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
 	hook, _ := webhookpayload.New()
 	payload, err := hook.Parse(r,
 		webhookpayload.RepoPushEvent,

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -22,7 +23,7 @@ const (
 func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
-	if p.configuration.WebhookSecret != params["webhooksecret"] {
+	if subtle.ConstantTimeCompare([]byte(p.configuration.WebhookSecret), []byte(params["webhooksecret"])) == 0 {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
 		return
 	}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -30,7 +30,6 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Webhook not found in config", http.StatusInternalServerError)
 		return
 	}
-	p.API.LogWarn("log ", "webhooksecret", config.WebhookSecret, "secret", secret)
 	if subtle.ConstantTimeCompare([]byte(config.WebhookSecret), []byte(secret)) == 0 {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
 		return


### PR DESCRIPTION
added a token which is the webhook secret which gets generated while configuring the bitbucket plugin and cross checked when ever any call happens to webhook 

ticket here
https://github.com/mattermost/mattermost-plugin-bitbucket/issues/24