### PR TITLE
[MM-36082] Remove non-functional flag to support private repos

### DIFF
--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -62,9 +62,8 @@ Open **System Console &gt; Plugins &gt; Bitbucket** and do the following:
 
 1. Generate a new value for **At Rest Encryption Key**.
 2. \(Optional\) **Bitbucket Organization:** Lock the plugin to a single Bitbucket organization by setting this field to the name of your Bitbucket organization.
-3. \(Optional\) **Enable Private Repositories:** Allow the plugin to receive notifications from private repositories by setting this value to true.
-4. Select **Save**.
-5. Go to **System Console &gt; Plugins &gt; Management** and select **Enable** to enable the Bitbucket plugin.
+3. Select **Save**.
+4. Go to **System Console &gt; Plugins &gt; Management** and select **Enable** to enable the Bitbucket plugin.
 
 You're all set!
 

--- a/plugin.json
+++ b/plugin.json
@@ -50,12 +50,6 @@
                 "display_name": "Bitbucket Organization",
                 "type": "text",
                 "help_text": "(Optional) Set to lock the plugin to a single Bitbucket organization."
-            },
-            {
-                "key": "EnablePrivateRepo",
-                "display_name": "Enable Private Repositories",
-                "type": "bool",
-                "help_text": "(Optional) Allow the plugin to work with private repositories. Enabling private repositories will require existing users to reconnect their accounts to gain access to private repositories. A message will be automatically be sent to affected users next time they load Mattermost alerting them of this."
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/kosgrz/mattermost-plugin-bitbucket)."

--- a/server/api.go
+++ b/server/api.go
@@ -428,25 +428,6 @@ func (p *Plugin) getConnected(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	privateRepoStoreKey := info.UserID + BitbucketPrivateRepoKey
-	if config.EnablePrivateRepo && !info.AllowedPrivateRepos {
-		val, err := p.API.KVGet(privateRepoStoreKey)
-		if err != nil {
-			p.API.LogError("Unable to get private repo key value", "err", err.Error())
-			return
-		}
-
-		// Inform the user once that private repositories enabled
-		if val == nil {
-			p.CreateBotDMPost(info.UserID, "Private repositories have been enabled for this plugin. To be able to use them you must disconnect and reconnect your BitBucket account. To reconnect your account, use the following slash commands: `/bitbucket disconnect` followed by `/bitbucket connect private`.", "")
-
-			err := p.API.KVSet(privateRepoStoreKey, []byte("1"))
-			if err != nil {
-				p.API.LogError("Unable to set private repo key value", "err", err.Error())
-			}
-		}
-	}
-
 	p.writeJSON(w, resp)
 }
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -64,7 +64,6 @@ func TestPlugin_ServeHTTP(t *testing.T) {
 					BitbucketOAuthClientID:     "mockID",
 					BitbucketOAuthClientSecret: "mockSecret",
 					WebhookSecret:              "mockSecret",
-					EnablePrivateRepo:          false,
 					EncryptionKey:              "mockKey",
 				})
 			p.initializeAPI()
@@ -114,7 +113,6 @@ func TestGetToken(t *testing.T) {
 					BitbucketOAuthClientID:     "mockID",
 					BitbucketOAuthClientSecret: "mockSecret",
 					WebhookSecret:              "mockSecret",
-					EnablePrivateRepo:          false,
 					EncryptionKey:              "mockKey",
 				})
 			p.initializeAPI()

--- a/server/command.go
+++ b/server/command.go
@@ -305,26 +305,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			return &model.CommandResponse{}, nil
 		}
 
-		privateAllowed := false
-		if len(parameters) > 0 {
-			if len(parameters) != 1 || parameters[0] != "private" {
-				p.postCommandResponse(args, fmt.Sprintf("Unknown command `%v`. Do you meant `/bitbucket connect private`?", args.Command))
-				return &model.CommandResponse{}, nil
-			}
-
-			privateAllowed = true
-		}
-
-		qparams := ""
-		if privateAllowed {
-			if !p.getConfiguration().EnablePrivateRepo {
-				p.postCommandResponse(args, "Private repositories are disabled. Please ask a System Admin to enabled them.")
-				return &model.CommandResponse{}, nil
-			}
-			qparams = "?private=true"
-		}
-
-		msg := fmt.Sprintf("[Click here to link your Bitbucket account.](%s/plugins/bitbucket/oauth/connect%s)", *siteURL, qparams)
+		msg := fmt.Sprintf("[Click here to link your Bitbucket account.](%s/plugins/bitbucket/oauth/connect)", *siteURL)
 		p.postCommandResponse(args, msg)
 		return &model.CommandResponse{}, nil
 	}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -22,7 +22,6 @@ type Configuration struct {
 	BitbucketOAuthClientID     string
 	BitbucketOAuthClientSecret string
 	WebhookSecret              string
-	EnablePrivateRepo          bool
 	EncryptionKey              string
 }
 

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -75,14 +75,6 @@ const manifestStr = `
         "help_text": "(Optional) Set to lock the plugin to a single Bitbucket organization.",
         "placeholder": "",
         "default": null
-      },
-      {
-        "key": "EnablePrivateRepo",
-        "display_name": "Enable Private Repositories",
-        "type": "bool",
-        "help_text": "(Optional) Allow the plugin to work with private repositories. Enabling private repositories will require existing users to reconnect their accounts to gain access to private repositories. A message will be automatically be sent to affected users next time they load Mattermost alerting them of this.",
-        "placeholder": "",
-        "default": null
       }
     ]
   }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -28,9 +28,8 @@ import (
 )
 
 const (
-	BitbucketTokenKey       = "_bitbuckettoken"
-	BitbucketAccountIDKey   = "_bitbucketaccountid"
-	BitbucketPrivateRepoKey = "_bitbucketprivate"
+	BitbucketTokenKey     = "_bitbuckettoken"
+	BitbucketAccountIDKey = "_bitbucketaccountid"
 
 	BitbucketBaseURL = "https://bitbucket.org/"
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -176,13 +176,12 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 }
 
 type BitbucketUserInfo struct {
-	UserID              string
-	Token               *oauth2.Token
-	BitbucketUsername   string
-	BitbucketAccountID  string
-	LastToDoPostAt      int64
-	Settings            *UserSettings
-	AllowedPrivateRepos bool
+	UserID             string
+	Token              *oauth2.Token
+	BitbucketUsername  string
+	BitbucketAccountID string
+	LastToDoPostAt     int64
+	Settings           *UserSettings
 }
 
 type UserSettings struct {

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -65,14 +65,6 @@ const manifest = JSON.parse(`
                 "help_text": "(Optional) Set to lock the plugin to a single Bitbucket organization.",
                 "placeholder": "",
                 "default": null
-            },
-            {
-                "key": "EnablePrivateRepo",
-                "display_name": "Enable Private Repositories",
-                "type": "bool",
-                "help_text": "(Optional) Allow the plugin to work with private repositories. Enabling private repositories will require existing users to reconnect their accounts to gain access to private repositories. A message will be automatically be sent to affected users next time they load Mattermost alerting them of this.",
-                "placeholder": "",
-                "default": null
             }
         ]
     }


### PR DESCRIPTION
#### Summary
This PR removed a non-functional flag to support private repos. Given that there is no Oauth2 scope for private repos, it's also unneeded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36082
