### PR TITLE
[issue 47] Cross-plugin task: Enable the CircleCI "test" job in each plugin repo that has a webapp plugin 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,22 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - plugin-ci/test:
+          filters:
+            tags:
+              only: /^v.*/
       - plugin-ci/coverage:
           filters:
             tags:
               only: /^v.*/
+          requires:
+            - plugin-ci/test
       - plugin-ci/build:
           filters:
             tags:
               only: /^v.*/
+          requires:
+            - plugin-ci/test
       - plugin-ci/deploy-ci:
           filters:
             branches:
@@ -40,6 +48,7 @@ workflows:
             - plugin-ci/lint
             - plugin-ci/coverage
             - plugin-ci/build
+            - plugin-ci/test
       - plugin-ci/deploy-release-github:
           filters:
             tags:
@@ -51,3 +60,4 @@ workflows:
             - plugin-ci/lint
             - plugin-ci/coverage
             - plugin-ci/build
+            - plugin-ci/test


### PR DESCRIPTION
Configured `plugin-ci/test' for bitbucket

Ticket here
Fixes #47 