### PR TITLE
[issue 58] Webhook delivery shows > for quote formatting when description or check-in comment is blank 

### DIFF
--- a/server/templaterenderer/template.go
+++ b/server/templaterenderer/template.go
@@ -78,7 +78,7 @@ func (tr *templateRenderer) init() {
 	// Quote the body
 	funcMap["quote"] = func(body string) string {
 		if body == "" {
-			return body
+			return ""
 		}
 		return ">" + strings.ReplaceAll(body, "\n", "\n>")
 	}

--- a/server/templaterenderer/template.go
+++ b/server/templaterenderer/template.go
@@ -77,6 +77,9 @@ func (tr *templateRenderer) init() {
 	var funcMap = sprig.TxtFuncMap()
 	// Quote the body
 	funcMap["quote"] = func(body string) string {
+		if body == "" {
+			return body
+		}
 		return ">" + strings.ReplaceAll(body, "\n", "\n>")
 	}
 


### PR DESCRIPTION
fixed of post which shows `>` if description is blank in create and update issue


ticket here

Fixes #58 