### PR TITLE
Added redirect

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,1 +1,4 @@
 root: ./docs/
+
+redirects:
+  bitbucket-plugin: mattermost-integrations.md


### PR DESCRIPTION
Redirect takes user to new GitBook page where they can follow a link to the new docs home via GitHub README.